### PR TITLE
reuseAddr for UDP socket bindings

### DIFF
--- a/network/StageLinqListener.ts
+++ b/network/StageLinqListener.ts
@@ -17,7 +17,8 @@ export class StageLinqListener {
    * @param callback Callback when new device is discovered.
    */
   listenForDevices(callback: DeviceDiscoveryCallback) {
-    const client = createSocket('udp4');
+    
+    const client = createSocket({type: 'udp4', reuseAddr: true});
     client.on('message', (p_announcement: Uint8Array, p_remote: RemoteInfo) => {
       const ctx = new ReadContext(p_announcement.buffer, false);
       const result = this.readConnectionInfo(ctx, p_remote.address);

--- a/network/announce.ts
+++ b/network/announce.ts
@@ -47,7 +47,7 @@ function writeDiscoveryMessage(p_ctx: WriteContext, p_message: DiscoveryMessage)
 async function initUdpSocket(): Promise<UDPSocket> {
   return new Promise<UDPSocket>((resolve, reject) => {
     try {
-      const client = createSocket('udp4');
+      const client = createSocket({type: 'udp4', reuseAddr: true});
       client.bind(); // we need to bind to a random port in order to enable broadcasting
       client.on('listening', () => {
         client.setBroadcast(true); // needs to be true in order to UDP multicast on MacOS


### PR DESCRIPTION
Currently, if another StageLinq software is running and bound to port 51337, library may throw `Error: bind EADDRINUSE`.
Passing `reuseAddr: true` to createSocket should prevent this.

Tested on:

- MacOS 11.7
- Windows 10 Pro 21H2 * _note: Partially. Having hard time recreating error condition_