### PR TITLE
Fix Windows dissector install instructions

### DIFF
--- a/tools/wireshark/README.md
+++ b/tools/wireshark/README.md
@@ -20,9 +20,17 @@ cp stagelinq.lua ~/.local/lib/wireshark/plugins/
 ```
 
 ### Windows
-Copy `stagelinq.lua` to:
+
+From Command Prompt:
+```cmd
+mkdir "%APPDATA%\Wireshark\plugins"
+copy stagelinq.lua "%APPDATA%\Wireshark\plugins\"
 ```
-%APPDATA%\Wireshark\plugins\
+
+From PowerShell:
+```powershell
+New-Item -ItemType Directory -Force -Path "$env:APPDATA\Wireshark\plugins"
+Copy-Item stagelinq.lua "$env:APPDATA\Wireshark\plugins\"
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- The `%APPDATA%\Wireshark\plugins\` directory does not exist by default on Windows, so the current instructions fail
- Added `mkdir` step to match the macOS/Linux instructions
- Added separate commands for Command Prompt and PowerShell since `%APPDATA%` expansion differs between shells

## Test plan
- [x] Verify Command Prompt instructions work on a fresh Windows install with Wireshark
- [x] Verify PowerShell instructions work on a fresh Windows install with Wireshark

🤖 Generated with [Claude Code](https://claude.com/claude-code)